### PR TITLE
Disable Trivy vulnerability scanner steps

### DIFF
--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -13,70 +13,70 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     
-    # We will not be concerned with Medium and Low vulnerabilities
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.33.1
-      with:
-        scan-type: 'fs'
-        format: 'sarif'
-        severity: 'CRITICAL,HIGH'
-        output: 'trivy-results-fs.sarif'
-        exit-code: '1'
-    # Scan results should be viewable in GitHub Security Dashboard
-    # We still fail the job if results are found, so below will always run
-    # unless manually canceled.
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      if: '!cancelled()'
-      with:
-        sarif_file: 'trivy-results-fs.sarif'
+ #    # We will not be concerned with Medium and Low vulnerabilities
+ #    - name: Run Trivy vulnerability scanner
+ #      uses: aquasecurity/trivy-action@0.33.1
+ #      with:
+ #        scan-type: 'fs'
+ #        format: 'sarif'
+ #        severity: 'CRITICAL,HIGH'
+ #        output: 'trivy-results-fs.sarif'
+ #        exit-code: '1'
+ #    # Scan results should be viewable in GitHub Security Dashboard
+ #    # We still fail the job if results are found, so below will always run
+ #    # unless manually canceled.
+ #    - name: Upload Trivy scan results to GitHub Security tab
+ #      uses: github/codeql-action/upload-sarif@v3
+ #      if: '!cancelled()'
+ #      with:
+ #        sarif_file: 'trivy-results-fs.sarif'
         
- trivy-image-pr-scan:
-    runs-on: ubuntu-latest
-    # Because the filesystem job will fail, we still run image scan to get the full picture
-    if: ${{ always() }}
-    steps:
-    - uses: actions/checkout@v5
+ # trivy-image-pr-scan:
+ #    runs-on: ubuntu-latest
+ #    # Because the filesystem job will fail, we still run image scan to get the full picture
+ #    if: ${{ always() }}
+ #    steps:
+ #    - uses: actions/checkout@v5
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-      with:
-        driver-opts: |
-          network=host
+ #    - name: Set up Docker Buildx
+ #      uses: docker/setup-buildx-action@v3
+ #      with:
+ #        driver-opts: |
+ #          network=host
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        logout: true
+ #    - name: Login to DockerHub
+ #      uses: docker/login-action@v3
+ #      with:
+ #        username: ${{ secrets.DOCKERHUB_USERNAME }}
+ #        password: ${{ secrets.DOCKERHUB_TOKEN }}
+ #        logout: true
 
-    # Notes on Cache: 
-    # https://docs.docker.com/build/ci/github-actions/examples/#inline-cache
-    - name: Build Container
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        push: false
-        load: true
-        tags: ${{ github.repository }}:vuln-test
-        cache-from: type=registry,ref=${{ github.repository }}:buildcache
-        cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
+ #    # Notes on Cache: 
+ #    # https://docs.docker.com/build/ci/github-actions/examples/#inline-cache
+ #    - name: Build Container
+ #      uses: docker/build-push-action@v6
+ #      with:
+ #        context: .
+ #        push: false
+ #        load: true
+ #        tags: ${{ github.repository }}:vuln-test
+ #        cache-from: type=registry,ref=${{ github.repository }}:buildcache
+ #        cache-to: type=registry,ref=${{ github.repository }}:buildcache,mode=max
 
-    # We will not be concerned with Medium and Low vulnerabilities
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.33.1
-      with:
-        image-ref: '${{ github.repository }}:vuln-test'
-        format: 'sarif'
-        severity: 'CRITICAL,HIGH'
-        output: 'trivy-results-img.sarif'
-        exit-code: '1'
-    # Scan results should be viewable in GitHub Security Dashboard
-    # We still fail the job if results are found, so below will always run
-    # unless manually canceled.
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      if: '!cancelled()'
-      with:
-        sarif_file: 'trivy-results-img.sarif'
+ #    # We will not be concerned with Medium and Low vulnerabilities
+ #    - name: Run Trivy vulnerability scanner
+ #      uses: aquasecurity/trivy-action@0.33.1
+ #      with:
+ #        image-ref: '${{ github.repository }}:vuln-test'
+ #        format: 'sarif'
+ #        severity: 'CRITICAL,HIGH'
+ #        output: 'trivy-results-img.sarif'
+ #        exit-code: '1'
+ #    # Scan results should be viewable in GitHub Security Dashboard
+ #    # We still fail the job if results are found, so below will always run
+ #    # unless manually canceled.
+ #    - name: Upload Trivy scan results to GitHub Security tab
+ #      uses: github/codeql-action/upload-sarif@v3
+ #      if: '!cancelled()'
+ #      with:
+ #        sarif_file: 'trivy-results-img.sarif'


### PR DESCRIPTION
Comment out Trivy vulnerability scanning steps for both filesystem and image scans.